### PR TITLE
fix: pin Python version to 3.12.*

### DIFF
--- a/wasmer.toml
+++ b/wasmer.toml
@@ -1,5 +1,5 @@
 [dependencies]
-"wasmer/python" = "^3.12.6"
+"wasmer/python" = "~3.12.6"
 
 [fs]
 "/src" = "./src"


### PR DESCRIPTION
The Python 3.13 release doesn't work correctly.